### PR TITLE
[feature] Add mailtrap option

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,17 +38,18 @@ Rails.application.configure do
 
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  if (mailtrap_username = ENV.fetch('MAILTRAP_USERNAME') { nil }) &&
-     (mailtrap_password = ENV.fetch('MAILTRAP_PASSWORD') { nil })
+  if (google_username = ENV.fetch('GOOGLE_USERNAME') { nil }) &&
+     (google_password = ENV.fetch('GOOGLE_PASSWORD') { nil })
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-      user_name: mailtrap_username,
-      password: mailtrap_password,
-      address: 'smtp.mailtrap.io',
-      domain: 'smtp.mailtrap.io',
-      port: '2525',
-      authentication: :cram_md5
+      user_name: google_username,
+      password: google_password,
+      address: 'smtp.gmail.com',
+      domain: 'hello.world.com',
+      port: '587',
+      authentication: 'plain',
+      enable_starttls_auto: true
     }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,4 +37,18 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  if (mailtrap_username = ENV.fetch('MAILTRAP_USERNAME') { nil }) &&
+     (mailtrap_password = ENV.fetch('MAILTRAP_PASSWORD') { nil })
+
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      user_name: mailtrap_username,
+      password: mailtrap_password,
+      address: 'smtp.mailtrap.io',
+      domain: 'smtp.mailtrap.io',
+      port: '2525',
+      authentication: :cram_md5
+    }
+  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - DB_PASSWORD=electron
       - CONFIRMATION_URI=https://localhost:5000/#/portal/register/confirmation
       - RESET_PASSWORD_URI=https://localhost:5000/#/portal/forgot-password/reset-form
+      - MAILTRAP_USERNAME=$MAILTRAP_USERNAME
+      - MAILTRAP_PASSWORD=$MAILTRAP_PASSWORD
     volumes:
       - .:/app
       - bundler_gems:/usr/local/bundle/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - DB_PASSWORD=electron
       - CONFIRMATION_URI=https://localhost:5000/#/portal/register/confirmation
       - RESET_PASSWORD_URI=https://localhost:5000/#/portal/forgot-password/reset-form
-      - MAILTRAP_USERNAME=$MAILTRAP_USERNAME
-      - MAILTRAP_PASSWORD=$MAILTRAP_PASSWORD
+      - GOOGLE_USERNAME=$GOOGLE_USERNAME
+      - GOOGLE_PASSWORD=$GOOGLE_PASSWORD
     volumes:
       - .:/app
       - bundler_gems:/usr/local/bundle/


### PR DESCRIPTION
To send to mailtrap, set the environment variables `MAILTRAP_USERNAME` and `MAILTRAP_PASSWORD` (preferably in `.env`) to test the SMTP functionality. Used in automated testing. 